### PR TITLE
Workaround for #2 by overriding bond orders in carboxylates

### DIFF
--- a/ConvertParameters.py
+++ b/ConvertParameters.py
@@ -3,6 +3,8 @@ import openeye.oechem as OEChem
 import parmed as ParmEd
 from openforcefield.topology import Molecule
 from simtk import unit
+from utils import fix_carboxylate_bond_orders
+
 
 def props(cls):
   return [ i for i in cls.__dict__.keys() if i[:1] != '_' ]
@@ -133,6 +135,7 @@ def get_smarts(prefix, atom_idxs):
   """Get the SMARTS corresponding to a list of atom indices"""
 
   offmol = Molecule.from_file(prefix + '.mol2')
+  fix_carboxylate_bond_orders(offmol)
   if prefix in prefix2pmd_struct:
     pmd_struct = prefix2pmd_struct[prefix]
   else:    
@@ -171,6 +174,7 @@ def get_smarts(prefix, atom_idxs):
   smiles = OEChem.OECreateSmiString(subsetmol, smiles_options)
 
   return smiles
+
 
 # Lists of residues that can occur at various positions on the tripeptide
 allres = [ 'ALA', 'ARG', 'ASH', 'ASN', 'ASP', 'GLH', 'GLN', 'GLU', 'GLY', 'HID', 'HIE', 'HIP',

--- a/test_parameterize.py
+++ b/test_parameterize.py
@@ -1,0 +1,10 @@
+from openforcefield.topology import Molecule
+from openforcefield.typing.engines.smirnoff import ForceField
+ff = ForceField('test.offxml')
+for folder in ['CTerminal', 'NTerminal', 'MainChain']:
+    mol = Molecule.from_file(f'{folder}/PRO/PRO.mol2')
+    from utils import fix_carboxylate_bond_orders
+    fix_carboxylate_bond_orders(mol)
+    sys = ff.create_openmm_system(mol.to_topology())
+    from simtk.openmm import XmlSerializer
+    print(XmlSerializer.serialize(sys))

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,19 @@
+
+def fix_carboxylate_bond_orders(offmol):
+  """Fix problem where leap-produced mol2 files have carboxylates defined with all single bonds"""
+  # First, find carbanions
+  for atom1 in offmol.atoms:
+    if atom1.atomic_number == 6 and atom1.formal_charge == -1:
+        # Then, see if they're bound to TWO oxyanions
+        oxyanion_seen = False
+        for bond in atom1.bonds:
+            atom2 = [atom for atom in bond.atoms if not atom == atom1][0]
+            if atom2.element.atomic_number == 8 and atom2.formal_charge == -1:
+                # If we find a bond to a SECOND carbanion, then zero both 
+                # the carbon and the second oxygen's formal charges, and 
+                # set the bond order to 2
+                if oxyanion_seen:
+                    atom1._formal_charge = 0
+                    atom2._formal_charge = 0
+                    bond._bond_order = 2
+                oxyanion_seen = True


### PR DESCRIPTION
Makes issue #2 non-blocking by searching for carboxylates with incorrectly-set bond orders, and writing in the correct ones. 