### PR TITLE
Don't add redundant dihedral terms when they are seen multiple times in one structure

### DIFF
--- a/ConvertParameters.py
+++ b/ConvertParameters.py
@@ -166,16 +166,16 @@ def get_smarts(prefix, atom_idxs):
 
 
 # Lists of residues that can occur at various positions on the tripeptide
-#allres = [ 'ALA', 'ARG', 'ASH', 'ASN', 'ASP', 'GLH', 'GLN', 'GLU', 'GLY', 'HID', 'HIE', 'HIP',
-#           'ILE', 'LEU', 'LYN', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL',
-#           'CYX' ]
-#trmres = [ 'ALA', 'ARG', 'ASN', 'ASP', 'GLN', 'GLU', 'GLY', 'HID', 'HIE', 'HIP', 'ILE', 'LEU',
-#           'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL', 'CYX' ]
+allres = [ 'ALA', 'ARG', 'ASH', 'ASN', 'ASP', 'GLH', 'GLN', 'GLU', 'GLY', 'HID', 'HIE', 'HIP',
+           'ILE', 'LEU', 'LYN', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL',
+           'CYX' ]
+trmres = [ 'ALA', 'ARG', 'ASN', 'ASP', 'GLN', 'GLU', 'GLY', 'HID', 'HIE', 'HIP', 'ILE', 'LEU',
+           'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL', 'CYX' ]
 
-allres = ['CYX'] #, 'HID', 'HIE']
+#allres = ['CYX'] #, 'HID', 'HIE']
 #allres = ['HIP', 'HID', 'HIE', 'GLY']
 #trmres = ['HIP', 'HID', 'HIE', 'GLY']
-trmres = ['CYX']
+#trmres = ['CYX']
 
 # Main chain, N-terminal, and C-terminal residues
 ResClasses = [ 'MainChain', 'NTerminal', 'CTerminal' ]

--- a/ConvertParameters.py
+++ b/ConvertParameters.py
@@ -166,11 +166,16 @@ def get_smarts(prefix, atom_idxs):
 
 
 # Lists of residues that can occur at various positions on the tripeptide
-allres = [ 'ALA', 'ARG', 'ASH', 'ASN', 'ASP', 'GLH', 'GLN', 'GLU', 'GLY', 'HID', 'HIE', 'HIP',
-           'ILE', 'LEU', 'LYN', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL',
-           'CYX' ]
-trmres = [ 'ALA', 'ARG', 'ASN', 'ASP', 'GLN', 'GLU', 'GLY', 'HID', 'HIE', 'HIP', 'ILE', 'LEU',
-           'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL', 'CYX' ]
+#allres = [ 'ALA', 'ARG', 'ASH', 'ASN', 'ASP', 'GLH', 'GLN', 'GLU', 'GLY', 'HID', 'HIE', 'HIP',
+#           'ILE', 'LEU', 'LYN', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL',
+#           'CYX' ]
+#trmres = [ 'ALA', 'ARG', 'ASN', 'ASP', 'GLN', 'GLU', 'GLY', 'HID', 'HIE', 'HIP', 'ILE', 'LEU',
+#           'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL', 'CYX' ]
+
+allres = ['CYX'] #, 'HID', 'HIE']
+#allres = ['HIP', 'HID', 'HIE', 'GLY']
+#trmres = ['HIP', 'HID', 'HIE', 'GLY']
+trmres = ['CYX']
 
 # Main chain, N-terminal, and C-terminal residues
 ResClasses = [ 'MainChain', 'NTerminal', 'CTerminal' ]
@@ -494,6 +499,33 @@ for angle in AllAngls:
 amber_proper_k_unit = unit.kilocalorie_per_mole
 amber_proper_phase_unit = unit.degree
 proper_dicts = {}
+
+# Prepare a helper function to determine whether this exact dihedral has
+# already been defined. This is a problem because dihedrals "stack" due
+# to their multiple possible periodicities, so we need to ensure that 
+# we don't stack the same term multiple times
+
+# This method assumes that the terms already have the same SMIRKS,
+# but may be redundant in ALL of their data fields
+def dihedral_term_already_defined(dihe_dict, k, phase, periodicity, idivf):
+  """
+  Returns True if this exact dihedral (periodicity, k, phase, idivf)
+  is already defined under this SMIRKS. This is useful in cases where
+  we might see the same dihedral term multiple times and want to check
+  whether a particular periodicity term is already known and shouldn't
+  be repeated (for example, the two CYX residues in a CYX dimer)
+  """
+  existing_index = 1
+  while f'k{existing_index}' in dihe_dict.keys():
+    if ((dihe_dict[f'k{existing_index}'] == k) and
+        (dihe_dict[f'phase{existing_index}'] == phase) and
+        (dihe_dict[f'periodicity{existing_index}'] == periodicity) and
+        (dihe_dict[f'idivf{existing_index}'] == idivf)):
+      return True
+    existing_index += 1
+  return False
+
+
 for dihedral in AllDihes:
   prmtop = PrmtopLibrary[dihedral.prmtopID]
   prefix = str(prmtop).replace('.prmtop','')
@@ -510,6 +542,12 @@ for dihedral in AllDihes:
   # idivfX values for X={1..4} (matching the k's)
   lookup_key = (smirks, parameter_name)
   dd = proper_dicts.get(lookup_key, dict())
+  if dihedral_term_already_defined(dd,
+                                   dihedral.K * amber_proper_k_unit,
+                                   dihedral.Phase * amber_proper_phase_unit,
+                                   dihedral.N,
+                                   1):
+    continue
   new_idx = 1
   while f'k{new_idx}' in dd.keys():
     new_idx += 1
@@ -525,7 +563,7 @@ for dihedral in AllDihes:
 amber_improper_k_unit = unit.kilocalorie_per_mole
 amber_improper_phase_unit = unit.degree
 improper_dicts = {}
-for dihedral in AllImprs[:500]:
+for dihedral in AllImprs:
   prmtop = PrmtopLibrary[dihedral.prmtopID]
   prefix = str(prmtop).replace('.prmtop','')
   resnames = prefix.split('/')[-1]
@@ -540,6 +578,12 @@ for dihedral in AllImprs[:500]:
                                dihedral.atom2pos, dihedral.atom4pos))
   lookup_key = (smirks, parameter_name)
   dd = improper_dicts.get(lookup_key, dict())
+  if dihedral_term_already_defined(dd,
+                                   dihedral.K * amber_proper_k_unit,
+                                   dihedral.Phase * amber_proper_phase_unit,
+                                   dihedral.N,
+                                   1):
+    continue
   new_idx = 1
   while f'k{new_idx}' in dd.keys():
     new_idx += 1

--- a/test_parameterize.py
+++ b/test_parameterize.py
@@ -35,14 +35,17 @@ for folder in ['MainChain', 'CTerminal', 'NTerminal']:#, 'MainChain']:
     #prefix = os.path.join('tests', 'issue_2_c_term_charge', folder, 'PRO', 'PRO')
     #resnames = ['GLY', 'ALA', 'PHE']
     if (folder == 'MainChain'):
-      resnames = [ 'ALA', 'ARG', 'ASH', 'ASN', 'ASP', 'GLH', 'GLN', 'GLU', 'GLY', # 'HID', 'HIE', 'HIP',
-                   'ILE', 'LEU', 'LYN', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TYR', 'VAL', # 'TRP',
-                   'CYX' ]
+      #resnames = [ 'ALA', 'ARG', 'ASH', 'ASN', 'ASP', 'GLH', 'GLN', 'GLU', 'GLY', # 'HID', 'HIE', 'HIP',
+      #             'ILE', 'LEU', 'LYN', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TYR', 'VAL', # 'TRP',
+      #             'CYX' ]
+      #resnames = ['HIP', 'HIE', 'HID', 'GLY']
+      resnames = ['CYX']#, 'HIE', 'HID']
     else:
-      resnames = [ 'ALA', 'ARG', 'ASN', 'ASP', 'GLN', 'GLU', 'GLY', # 'HID', 'HIE', 'HIP',
-                   'ILE', 'LEU', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TYR', 'VAL', # 'TRP',
-                   'CYX' ]
-
+      #resnames = [ 'ALA', 'ARG', 'ASN', 'ASP', 'GLN', 'GLU', 'GLY', # 'HID', 'HIE', 'HIP',
+      #             'ILE', 'LEU', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TYR', 'VAL', # 'TRP',
+      #             'CYX' ]
+      #resnames = ['HIP', 'HIE', 'HID', 'GLY']
+      resnames = ['CYX']
     for resname in resnames:
         prefix = os.path.join(folder, resname, resname)
         print()
@@ -70,7 +73,7 @@ for folder in ['MainChain', 'CTerminal', 'NTerminal']:#, 'MainChain']:
         #print(mol.to_smiles())
         from utils import fix_carboxylate_bond_orders
         fix_carboxylate_bond_orders(mol)
-        #print(mol.to_smiles())
+        print(mol.to_smiles())
         off_top = mol.to_topology()
         #off_top.box_vectors = [[48, 0, 0], [0, 48, 0], [0, 0, 48]] * unit.angstrom
         #print('off_box', off_top.box_vectors)
@@ -153,12 +156,18 @@ for folder in ['MainChain', 'CTerminal', 'NTerminal']:#, 'MainChain']:
               print('  Nearest match:      %9.5f %9.5f' % (nearmatch[0], nearmatch[1]))
 
         # Check on propers
-        for adihe in amber_struct.dihedrals:
+        #for adihe in amber_struct.dihedrals:
+        n_adihes = len([i for i in amber_struct.dihedrals])
+        n_imp_adihes = len([i for i in amber_struct.dihedrals if i.improper])
+        n_odihes = len([i for i in off_struct.dihedrals])
+        print(f'{n_adihes} amber dihedrals ({n_imp_adihes} impropers) and {n_odihes} off dihedrals')
+        for adihe in off_struct.dihedrals:
           #print(adihe.improper)
           index_found = 0
           parms_match = 0
           nearmatch = (0.0, 0.0, 0)
-          for odihe in off_struct.dihedrals:
+          #for odihe in off_struct.dihedrals:
+          for odihe in amber_struct.dihedrals:
             #print(odihe)
             if (adihe.atom1.idx == odihe.atom1.idx and adihe.atom2.idx == odihe.atom2.idx and
                 adihe.atom3.idx == odihe.atom3.idx and adihe.atom4.idx == odihe.atom4.idx):
@@ -185,9 +194,10 @@ for folder in ['MainChain', 'CTerminal', 'NTerminal']:#, 'MainChain']:
             #    adihe.atom3.idx == odihe.atom2.idx and adihe.atom4.idx == odihe.atom4.idx):
             if len(aset & oset) == 4:
               index_found = 1
-              if (abs(adihe.type.phi_k - (odihe.type.phi_k * 3)) < 1.0e-4 and
+              if (abs(adihe.type.phi_k - (odihe.type.phi_k / 3)) < 1.0e-4 and
                   abs(adihe.type.phase - odihe.type.phase) < 1.0e-4 and
-                  adihe.improper == True):
+                  #adihe.improper == True):
+                  odihe.improper == True):
                 parms_match = 1
               else:
                 nearmatch = (odihe.type.phi_k, odihe.type.phase, 1)

--- a/test_parameterize.py
+++ b/test_parameterize.py
@@ -35,17 +35,17 @@ for folder in ['MainChain', 'CTerminal', 'NTerminal']:#, 'MainChain']:
     #prefix = os.path.join('tests', 'issue_2_c_term_charge', folder, 'PRO', 'PRO')
     #resnames = ['GLY', 'ALA', 'PHE']
     if (folder == 'MainChain'):
-      #resnames = [ 'ALA', 'ARG', 'ASH', 'ASN', 'ASP', 'GLH', 'GLN', 'GLU', 'GLY', # 'HID', 'HIE', 'HIP',
-      #             'ILE', 'LEU', 'LYN', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TYR', 'VAL', # 'TRP',
-      #             'CYX' ]
+      resnames = [ 'ALA', 'ARG', 'ASH', 'ASN', 'ASP', 'GLH', 'GLN', 'GLU', 'GLY', # 'HID', 'HIE', 'HIP',
+                   'ILE', 'LEU', 'LYN', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TYR', 'VAL', # 'TRP',
+                   'CYX' ]
       #resnames = ['HIP', 'HIE', 'HID', 'GLY']
-      resnames = ['CYX']#, 'HIE', 'HID']
+      #resnames = ['CYX']#, 'HIE', 'HID']
     else:
-      #resnames = [ 'ALA', 'ARG', 'ASN', 'ASP', 'GLN', 'GLU', 'GLY', # 'HID', 'HIE', 'HIP',
-      #             'ILE', 'LEU', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TYR', 'VAL', # 'TRP',
-      #             'CYX' ]
+      resnames = [ 'ALA', 'ARG', 'ASN', 'ASP', 'GLN', 'GLU', 'GLY', # 'HID', 'HIE', 'HIP',
+                   'ILE', 'LEU', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TYR', 'VAL', # 'TRP',
+                   'CYX' ]
       #resnames = ['HIP', 'HIE', 'HID', 'GLY']
-      resnames = ['CYX']
+      #resnames = ['CYX']
     for resname in resnames:
         prefix = os.path.join(folder, resname, resname)
         print()


### PR DESCRIPTION
- [x] Fixes #13 

This PR fixes a bug in `ConvertParameters.py` caused by seeing the exact same dihedral term multiple times in one structure, but not deduplicating it. 

It also adds some debugging code (total proper/improper counts) that may be useful in debugging torsion energies in the future. 

@dscerutti -- If these changes look good to you, please go ahead and unilaterally merge. 