### PR TITLE
Fix improper energies

### DIFF
--- a/ConvertParameters.py
+++ b/ConvertParameters.py
@@ -5,6 +5,8 @@ from openforcefield.topology import Molecule
 from simtk import unit
 from utils import fix_carboxylate_bond_orders
 
+from amberimpropertorsionhandler import AmberImproperTorsionHandler
+
 
 def props(cls):
   return [ i for i in cls.__dict__.keys() if i[:1] != '_' ]
@@ -174,10 +176,10 @@ allres = [ 'ALA', 'ARG', 'ASH', 'ASN', 'ASP', 'GLH', 'GLN', 'GLU', 'GLY', 'HID',
 trmres = [ 'ALA', 'ARG', 'ASN', 'ASP', 'GLN', 'GLU', 'GLY', 'HID', 'HIE', 'HIP', 'ILE', 'LEU',
            'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL', 'CYX' ]
 
-#allres = ['ARG'] #, 'HID', 'HIE']
+#allres = ['GLU'] #, 'HID', 'HIE']
 #allres = ['HIP', 'HID', 'HIE', 'GLY']
 #trmres = ['HIP', 'HID', 'HIE', 'GLY']
-#trmres = ['ARG']
+#trmres = ['GLU']
 
 # Main chain, N-terminal, and C-terminal residues
 ResClasses = [ 'MainChain', 'NTerminal', 'CTerminal' ]
@@ -576,10 +578,10 @@ for dihedral in AllImprs:
   # It's important to note that the 2- and 3- position atom indices are switched below. In
   # AMBER, the 3-position atom is central in the improper.  In SMIRNOFF, the 2-position atom
   # is central.
-  smirks = get_smarts(prefix, (dihedral.atom1pos, dihedral.atom3pos,
-                               dihedral.atom2pos, dihedral.atom4pos))
-  #smirks = get_smarts(prefix, (dihedral.atom1pos, dihedral.atom2pos,
-  #                             dihedral.atom3pos, dihedral.atom4pos))
+  #smirks = get_smarts(prefix, (dihedral.atom1pos, dihedral.atom3pos,
+  #                             dihedral.atom2pos, dihedral.atom4pos))
+  smirks = get_smarts(prefix, (dihedral.atom1pos, dihedral.atom2pos,
+                               dihedral.atom3pos, dihedral.atom4pos))
   lookup_key = (smirks, parameter_name)
   dd = improper_dicts.get(lookup_key, dict())
   if dihedral_term_already_defined(dd,
@@ -670,7 +672,7 @@ ff._set_aromaticity_model('OEAroModel_MDL')
 # Loop over the parameters to convert and their corresponding SMIRNOFF header tags 
 for smirnoff_tag, param_dicts in { "Bonds": bond_dicts, "Angles": angle_dicts,
                                    "ProperTorsions": proper_dicts,
-                                   "ImproperTorsions": improper_dicts,
+                                   "AmberImproperTorsions": improper_dicts,
                                    'LibraryCharges': charge_dicts,
                                    'vdW': nonbond_dicts}.items():
   # Get the parameter handler for the given tag. The

--- a/ConvertParameters.py
+++ b/ConvertParameters.py
@@ -174,10 +174,10 @@ allres = [ 'ALA', 'ARG', 'ASH', 'ASN', 'ASP', 'GLH', 'GLN', 'GLU', 'GLY', 'HID',
 trmres = [ 'ALA', 'ARG', 'ASN', 'ASP', 'GLN', 'GLU', 'GLY', 'HID', 'HIE', 'HIP', 'ILE', 'LEU',
            'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL', 'CYX' ]
 
-#allres = ['GLU'] #, 'HID', 'HIE']
+#allres = ['ARG'] #, 'HID', 'HIE']
 #allres = ['HIP', 'HID', 'HIE', 'GLY']
 #trmres = ['HIP', 'HID', 'HIE', 'GLY']
-#trmres = ['GLU']
+#trmres = ['ARG']
 
 # Main chain, N-terminal, and C-terminal residues
 ResClasses = [ 'MainChain', 'NTerminal', 'CTerminal' ]
@@ -578,6 +578,8 @@ for dihedral in AllImprs:
   # is central.
   smirks = get_smarts(prefix, (dihedral.atom1pos, dihedral.atom3pos,
                                dihedral.atom2pos, dihedral.atom4pos))
+  #smirks = get_smarts(prefix, (dihedral.atom1pos, dihedral.atom2pos,
+  #                             dihedral.atom3pos, dihedral.atom4pos))
   lookup_key = (smirks, parameter_name)
   dd = improper_dicts.get(lookup_key, dict())
   if dihedral_term_already_defined(dd,
@@ -592,7 +594,7 @@ for dihedral in AllImprs:
   dd['smirks'] = smirks
   dd['id'] = parameter_name
   # TODO: Should we divide this by 3, since the SMIRNOFF improper will be applied three times?
-  dd[f'k{new_idx}'] = dihedral.K * amber_improper_k_unit / 3
+  dd[f'k{new_idx}'] = dihedral.K * amber_improper_k_unit #/ 3
   dd[f'phase{new_idx}'] = dihedral.Phase * amber_improper_phase_unit
   dd[f'periodicity{new_idx}'] = dihedral.N
   dd[f'idivf{new_idx}'] = 1

--- a/ConvertParameters.py
+++ b/ConvertParameters.py
@@ -111,6 +111,8 @@ def DefineDihe(dihedral, isimpr, topid):
     ths.N       = dihedral.type.per
     ths.SCNB    = round(dihedral.type.scnb, 5)
     ths.SCEE    = round(dihedral.type.scee, 5)
+  else:
+    ths.N       = 2
   ths.prmtopID  = topid
   ths.atom1pos  = dihedral.atom1.idx
   ths.atom2pos  = dihedral.atom2.idx
@@ -172,10 +174,10 @@ allres = [ 'ALA', 'ARG', 'ASH', 'ASN', 'ASP', 'GLH', 'GLN', 'GLU', 'GLY', 'HID',
 trmres = [ 'ALA', 'ARG', 'ASN', 'ASP', 'GLN', 'GLU', 'GLY', 'HID', 'HIE', 'HIP', 'ILE', 'LEU',
            'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL', 'CYX' ]
 
-#allres = ['CYX'] #, 'HID', 'HIE']
+#allres = ['GLU'] #, 'HID', 'HIE']
 #allres = ['HIP', 'HID', 'HIE', 'GLY']
 #trmres = ['HIP', 'HID', 'HIE', 'GLY']
-#trmres = ['CYX']
+#trmres = ['GLU']
 
 # Main chain, N-terminal, and C-terminal residues
 ResClasses = [ 'MainChain', 'NTerminal', 'CTerminal' ]

--- a/amberimpropertorsionhandler.py
+++ b/amberimpropertorsionhandler.py
@@ -1,0 +1,121 @@
+from openforcefield.typing.engines.smirnoff import ImproperTorsionHandler, ParameterAttribute, IndexedParameterAttribute
+from openforcefield.typing.engines.smirnoff.parameters import _allow_only
+from simtk import openmm
+
+# TODO: There's a lot of duplicated code in ProperTorsionHandler and ImproperTorsionHandler
+class AmberImproperTorsionHandler(ImproperTorsionHandler):
+    """Handle SMIRNOFF ``<AmberImproperTorsions>`` tags
+
+    .. warning :: This API is experimental and subject to change.
+    """
+
+    # class AmberImproperTorsionType(ParameterType):
+    #     """A SMIRNOFF torsion type for improper torsions.
+
+    #     .. warning :: This API is experimental and subject to change.
+    #     """
+    #     _VALENCE_TYPE = 'AmberImproperTorsion'
+    #     _ELEMENT_NAME = 'AmberImproper'
+
+    #     periodicity = IndexedParameterAttribute(converter=int)
+    #     phase = IndexedParameterAttribute(unit=unit.degree)
+    #     k = IndexedParameterAttribute(unit=unit.kilocalorie_per_mole)
+    #     idivf = IndexedParameterAttribute(default=None, converter=float)
+
+
+    _TAGNAME = 'AmberImproperTorsions'  # SMIRNOFF tag name to process
+    _INFOTYPE = ImproperTorsionHandler.ImproperTorsionType  # info type to store
+    _OPENMMTYPE = openmm.PeriodicTorsionForce  # OpenMM force class to create
+
+    potential = ParameterAttribute(
+        default='k*(1+cos(periodicity*theta-phase))',
+        converter=_allow_only(['k*(1+cos(periodicity*theta-phase))'])
+    )
+    default_idivf = ParameterAttribute(default='auto')
+
+    from openforcefield.topology.topology import _TransformedDict
+    class AmberImproperDict(_TransformedDict):
+        """Symmetrize improper torsions."""
+        
+        def __keytransform__(self, key):
+            """Only keep one improper per center, and assume that the central atom is the third one."""
+            # Ensure key is a tuple
+            key = tuple(key)
+            # Retrieve connected atoms
+            connectedatoms = [key[0], key[1], key[3]]
+            # Sort connected atoms
+            connectedatoms.sort()
+            # Re-store connected atoms
+            key = tuple(
+                [connectedatoms[0], connectedatoms[1], key[2], connectedatoms[2]])
+            return (key)
+
+    def find_matches(self, entity):
+        """Find the improper torsions in the topology/molecule matched by a parameter type.
+
+        Parameters
+        ----------
+        entity : openforcefield.topology.Topology
+            Topology to search.
+
+        Returns
+        ---------
+        matches : ImproperDict[Tuple[int], ParameterHandler._Match]
+            ``matches[atom_indices]`` is the ``ParameterType`` object
+            matching the 4-tuple of atom indices in ``entity``.
+
+        """
+        return self._find_matches(entity, transformed_dict_cls=self.AmberImproperDict)
+
+    def create_force(self, system, topology, **kwargs):
+        #force = super(ImproperTorsionHandler, self).create_force(system, topology, **kwargs)
+        #force = super().create_force(system, topology, **kwargs)
+        existing = [system.getForce(i) for i in range(system.getNumForces())]
+        existing = [
+            f for f in existing if type(f) == openmm.PeriodicTorsionForce
+        ]
+        if len(existing) == 0:
+            force = openmm.PeriodicTorsionForce()
+            system.addForce(force)
+        else:
+            force = existing[0]
+
+        # Add all improper torsions to the system
+        improper_matches = self.find_matches(topology)
+        # The atom indices in the key of the dictionary match have been rearranged and shouldn't be trusted
+        for (_, improper_match) in improper_matches.items():
+        #for (atom_indices, improper_match) in improper_matches.items():
+            # Ensure atoms are actually bonded correct pattern in Topology
+            # For impropers, central atom is atom 1
+            # for (i, j) in [(0, 1), (1, 2), (1, 3)]:
+            #     topology.assert_bonded(atom_indices[i], atom_indices[j])
+            self._assert_correct_connectivity(improper_match, [(0, 2), (1, 2), (2, 3)])
+            atom_indices = improper_match.environment_match.topology_atom_indices
+            improper = improper_match.parameter_type
+
+            # TODO: This is a lazy hack. idivf should be set according to the ParameterHandler's default_idivf attrib
+            if improper.idivf is None:
+                improper.idivf = [3 for item in improper.k]
+            # Impropers are applied in three paths around the trefoil having the same handedness
+            for (improper_periodicity, improper_phase, improper_k, improper_idivf) in zip(improper.periodicity,
+                                               improper.phase, improper.k, improper.idivf):
+                # TODO: Implement correct "auto" behavior
+                if improper_idivf == 'auto':
+                    improper_idivf = 3
+                    #logger.warning("The OpenForceField toolkit hasn't implemented "
+                    #               "support for the torsion `idivf` value of 'auto'."
+                    #               "Currently assuming a value of '3' for impropers.")
+                # Permute non-central atoms
+                #others = [atom_indices[0], atom_indices[2], atom_indices[3]]
+                ## ((0, 1, 2), (1, 2, 0), and (2, 0, 1)) are the three paths around the trefoil
+                #for p in [(others[i], others[j], others[k]) for (i, j, k) in [(0, 1, 2), (1, 2, 0), (2, 0, 1)]]:
+                #    # The torsion force gets added three times, since the k is divided by three
+                #    force.addTorsion(atom_indices[1], p[0], p[1], p[2],
+                #                     improper_periodicity, improper_phase, improper_k/improper_idivf)
+                force.addTorsion(atom_indices[0], atom_indices[1], atom_indices[2], atom_indices[3],
+                                 improper_periodicity, improper_phase, improper_k / improper_idivf)
+
+        #logger.info(
+        #    '{} AMBER-style impropers added, each applied strictly in the order that the SMIRKS matched the central atom'.format(
+        #        len(improper_matches)))
+

--- a/test_parameterize.py
+++ b/test_parameterize.py
@@ -7,6 +7,7 @@ from simtk.openmm.app import NoCutoff, HBonds
 from utils import fix_carboxylate_bond_orders
 import os
 
+from amberimpropertorsionhandler import AmberImproperTorsionHandler
 
 def calc_energy(omm_sys, omm_top, coords):
     omm_idx_to_force = {}
@@ -42,13 +43,13 @@ for folder in ['MainChain', 'CTerminal', 'NTerminal']:#, 'MainChain']:
                    'ILE', 'LEU', 'LYN', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TYR', 'VAL', 'TRP',
                    'CYX' ]
       #resnames = ['HIP', 'HIE', 'HID', 'GLY']
-      #resnames = ['ARG']#, 'HIE', 'HID']
+      #resnames = ['GLU']#, 'HIE', 'HID']
     else:
       resnames = [ 'ALA', 'ARG', 'ASN', 'ASP', 'GLN', 'GLU', 'GLY', 'HID', 'HIE', 'HIP',
                    'ILE', 'LEU', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TYR', 'VAL', 'TRP',
                    'CYX' ]
       #resnames = ['HIP', 'HIE', 'HID', 'GLY']
-      #resnames = ['ARG']
+      #resnames = ['GLU']
     for resname in resnames:
         prefix = os.path.join(folder, resname, resname)
         print()

--- a/test_parameterize.py
+++ b/test_parameterize.py
@@ -35,17 +35,17 @@ for folder in ['MainChain', 'CTerminal', 'NTerminal']:#, 'MainChain']:
     #prefix = os.path.join('tests', 'issue_2_c_term_charge', folder, 'PRO', 'PRO')
     #resnames = ['GLY', 'ALA', 'PHE']
     if (folder == 'MainChain'):
-      resnames = [ 'ALA', 'ARG', 'ASH', 'ASN', 'ASP', 'GLH', 'GLN', 'GLU', 'GLY', # 'HID', 'HIE', 'HIP',
-                   'ILE', 'LEU', 'LYN', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TYR', 'VAL', # 'TRP',
+      resnames = [ 'ALA', 'ARG', 'ASH', 'ASN', 'ASP', 'GLH', 'GLN', 'GLU', 'GLY',  'HID', 'HIE', 'HIP',
+                   'ILE', 'LEU', 'LYN', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TYR', 'VAL', 'TRP',
                    'CYX' ]
       #resnames = ['HIP', 'HIE', 'HID', 'GLY']
-      #resnames = ['CYX']#, 'HIE', 'HID']
+      #resnames = ['GLU']#, 'HIE', 'HID']
     else:
-      resnames = [ 'ALA', 'ARG', 'ASN', 'ASP', 'GLN', 'GLU', 'GLY', # 'HID', 'HIE', 'HIP',
-                   'ILE', 'LEU', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TYR', 'VAL', # 'TRP',
+      resnames = [ 'ALA', 'ARG', 'ASN', 'ASP', 'GLN', 'GLU', 'GLY', 'HID', 'HIE', 'HIP',
+                   'ILE', 'LEU', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TYR', 'VAL', 'TRP',
                    'CYX' ]
       #resnames = ['HIP', 'HIE', 'HID', 'GLY']
-      #resnames = ['CYX']
+      #resnames = ['GLU']
     for resname in resnames:
         prefix = os.path.join(folder, resname, resname)
         print()

--- a/test_parameterize.py
+++ b/test_parameterize.py
@@ -29,8 +29,11 @@ def calc_energy(omm_sys, omm_top, coords):
     return omm_energy
 
 
-
+#from openforcefield.typing.engines.smirnoff import ImproperTorsionHandler
+#ImproperTorsionHandler.ImproperTorsionType._VALENCE_TYPE = None
 ff = ForceField('test.offxml')
+#ff.get_parameter_handler('ImproperTorsions')._INFOTYPE._VALENCE_TYPE = None
+
 for folder in ['MainChain', 'CTerminal', 'NTerminal']:#, 'MainChain']:
     #prefix = os.path.join('tests', 'issue_2_c_term_charge', folder, 'PRO', 'PRO')
     #resnames = ['GLY', 'ALA', 'PHE']
@@ -39,13 +42,13 @@ for folder in ['MainChain', 'CTerminal', 'NTerminal']:#, 'MainChain']:
                    'ILE', 'LEU', 'LYN', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TYR', 'VAL', 'TRP',
                    'CYX' ]
       #resnames = ['HIP', 'HIE', 'HID', 'GLY']
-      #resnames = ['GLU']#, 'HIE', 'HID']
+      #resnames = ['ARG']#, 'HIE', 'HID']
     else:
       resnames = [ 'ALA', 'ARG', 'ASN', 'ASP', 'GLN', 'GLU', 'GLY', 'HID', 'HIE', 'HIP',
                    'ILE', 'LEU', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TYR', 'VAL', 'TRP',
                    'CYX' ]
       #resnames = ['HIP', 'HIE', 'HID', 'GLY']
-      #resnames = ['GLU']
+      #resnames = ['ARG']
     for resname in resnames:
         prefix = os.path.join(folder, resname, resname)
         print()
@@ -194,7 +197,11 @@ for folder in ['MainChain', 'CTerminal', 'NTerminal']:#, 'MainChain']:
             #    adihe.atom3.idx == odihe.atom2.idx and adihe.atom4.idx == odihe.atom4.idx):
             if len(aset & oset) == 4:
               index_found = 1
-              if (abs(adihe.type.phi_k - (odihe.type.phi_k / 3)) < 1.0e-4 and
+              #if (abs(adihe.type.phi_k - (odihe.type.phi_k / 3)) < 1.0e-4 and
+              #    abs(adihe.type.phase - odihe.type.phase) < 1.0e-4 and
+              #    #adihe.improper == True):
+              #    odihe.improper == True):
+              if (abs(adihe.type.phi_k - (odihe.type.phi_k)) < 1.0e-4 and
                   abs(adihe.type.phase - odihe.type.phase) < 1.0e-4 and
                   #adihe.improper == True):
                   odihe.improper == True):


### PR DESCRIPTION
- [x] Don't let `ImproperTorsionHandler` rearrange indices (change required in OFF Toolkit)
- [x] Turn off `ImproperTorsionHandler` valence checks (change required in OFF Toolkit)
- [x] Match exact atom order from AMBER in OFFXML
- [x] Set improper periodicities to 2
- [x] Don't divide improper k values by 3

For reference, the worst case of improper mismatch is NTerminal GLU

Before this PR:
```
NTerminal/GLU/GLU
HarmonicBondForce 2.1379218101501465 kJ/mol
HarmonicAngleForce 6.882795810699463 kJ/mol
PeriodicTorsionForce 46.8884162902832 kJ/mol
NonbondedForce -415.76202392578125 kJ/mol
-359.8529052734375 kJ/mol
[H][C@@](C(=O)N([H])C([H])([H])[H])(C([H])([H])C([H])([H])C(=O)[O-])[N+]([H])([H])[H]
HarmonicAngleForce 6.882845401763916 kJ/mol
HarmonicBondForce 2.1379215717315674 kJ/mol
NonbondedForce -415.7628173828125 kJ/mol
PeriodicTorsionForce 28.416242599487305 kJ/mol
-378.3258056640625 kJ/mol
67 amber dihedrals (3 impropers) and 73 off dihedrals
```