### PR TITLE
Control for HIS Resonance

### DIFF
--- a/ConvertParameters.py
+++ b/ConvertParameters.py
@@ -154,27 +154,11 @@ def remove_charge_and_bond_order_from_imidazole(offmol):
   mark the resonant bonds with a unique "$" character in the SMARTS, which we can later 
   replace. 
   """
-  #print(offmol.to_smiles())
   matches = offmol.chemical_environment_matches('[C:1]1~[C:2]~[N:3]~[C:4]~[N:5]1')
   all_imidazole_atoms = set()
   for match in matches:
     for idx in match:
       all_imidazole_atoms.add(idx)
-  #print(all_imidazole_atoms)
-  #1/0
-  # nx_mol = offmol.to_networkx()
-  # def node_match_func(x, y):
-  #   # always match by atleast atomic number
-  #   is_equal = x["atomic_number"] == y["atomic_number"]
-  #   if aromatic_matching:
-  #     is_equal &= x["is_aromatic"] == y["is_aromatic"]
-  #   if formal_charge_matching:
-  #     is_equal &= x["formal_charge"] == y["formal_charge"]
-  #   return is_equal
-  
-  # GM = GraphMatcher(
-  #   mol1_netx, mol2_netx, node_match=node_match_func
-  #   )
 
   for atom in offmol.atoms:
     if atom.molecule_atom_index in all_imidazole_atoms:
@@ -185,21 +169,6 @@ def remove_charge_and_bond_order_from_imidazole(offmol):
         (bond.atom2_index in all_imidazole_atoms)):
       bond.bond_order = 4
       
-    # if atom.element.symbol != "C":
-    #   continue
-    # nitrogen_neighbors = 0
-    # for neighbor in atom.bonded_atoms:
-    #   if neighbor.element.symbol == "N":
-    #     nitrogen_neighbors += 1
-    # if nitrogen_neighbors != 3:
-    #   continue
-    # atom.formal_charge = 0
-    # for neighbor in atom.bonded_atoms:
-    #   neighbor.formal_charge = 0
-    # for bond in atom.bonds:
-    #   # Set bond order 4, which will produce a "$" character. We later replace this with "~".
-    #   bond.bond_order = 4
-        
 
 prefix2pmd_struct = {}
 def get_smarts(prefix, atom_idxs):

--- a/ConvertParameters.py
+++ b/ConvertParameters.py
@@ -147,6 +147,58 @@ def remove_charge_and_bond_order_from_guanidinium(offmol):
       # Set bond order 4, which will produce a "$" character. We later replace this with "~".
       bond.bond_order = 4
     
+def remove_charge_and_bond_order_from_imidazole(offmol):
+  """
+  To correct for chemical perception issues with possible resonance states of histidine, 
+  remove all charge from the imidazole group, and set all bond orders to 4. This will
+  mark the resonant bonds with a unique "$" character in the SMARTS, which we can later 
+  replace. 
+  """
+  #print(offmol.to_smiles())
+  matches = offmol.chemical_environment_matches('[C:1]1~[C:2]~[N:3]~[C:4]~[N:5]1')
+  all_imidazole_atoms = set()
+  for match in matches:
+    for idx in match:
+      all_imidazole_atoms.add(idx)
+  #print(all_imidazole_atoms)
+  #1/0
+  # nx_mol = offmol.to_networkx()
+  # def node_match_func(x, y):
+  #   # always match by atleast atomic number
+  #   is_equal = x["atomic_number"] == y["atomic_number"]
+  #   if aromatic_matching:
+  #     is_equal &= x["is_aromatic"] == y["is_aromatic"]
+  #   if formal_charge_matching:
+  #     is_equal &= x["formal_charge"] == y["formal_charge"]
+  #   return is_equal
+  
+  # GM = GraphMatcher(
+  #   mol1_netx, mol2_netx, node_match=node_match_func
+  #   )
+
+  for atom in offmol.atoms:
+    if atom.molecule_atom_index in all_imidazole_atoms:
+      atom.formal_charge = 0
+      
+  for bond in offmol.bonds:
+    if ((bond.atom1_index in all_imidazole_atoms) and
+        (bond.atom2_index in all_imidazole_atoms)):
+      bond.bond_order = 4
+      
+    # if atom.element.symbol != "C":
+    #   continue
+    # nitrogen_neighbors = 0
+    # for neighbor in atom.bonded_atoms:
+    #   if neighbor.element.symbol == "N":
+    #     nitrogen_neighbors += 1
+    # if nitrogen_neighbors != 3:
+    #   continue
+    # atom.formal_charge = 0
+    # for neighbor in atom.bonded_atoms:
+    #   neighbor.formal_charge = 0
+    # for bond in atom.bonds:
+    #   # Set bond order 4, which will produce a "$" character. We later replace this with "~".
+    #   bond.bond_order = 4
         
 
 prefix2pmd_struct = {}
@@ -156,6 +208,7 @@ def get_smarts(prefix, atom_idxs):
   offmol = Molecule.from_file(prefix + '.mol2')
   fix_carboxylate_bond_orders(offmol)
   remove_charge_and_bond_order_from_guanidinium(offmol)
+  remove_charge_and_bond_order_from_imidazole(offmol)
   if prefix in prefix2pmd_struct:
     pmd_struct = prefix2pmd_struct[prefix]
   else:    
@@ -680,6 +733,9 @@ def sort_method(x):
   # Ensure that CYS parameters are not partially overridden by CYX
   if 'CYX' in x['id']:
     sort_key += 'A'
+  # Because HID and HIE are substructures of HIP, make sure HIP comes LAST
+  elif 'HIP' in x['id']:
+    sort_key += 'Z'
   else:
     sort_key += 'B'
   # Add a heuristic for "specificness" of a given smarts by looking at the smirks's length

--- a/test_parameterize_tripeptides.py
+++ b/test_parameterize_tripeptides.py
@@ -40,17 +40,17 @@ for folder in ['MainChain', 'CTerminal', 'NTerminal']:#, 'MainChain']:
     #prefix = os.path.join('tests', 'issue_2_c_term_charge', folder, 'PRO', 'PRO')
     #resnames = ['GLY', 'ALA', 'PHE']
     if (folder == 'MainChain'):
-      #resnames = [ 'ALA', 'ARG', 'ASH', 'ASN', 'ASP', 'GLH', 'GLN', 'GLU', 'GLY',  'HID', 'HIE', 'HIP',
-      #             'ILE', 'LEU', 'LYN', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TYR', 'VAL', 'TRP',]
+      resnames = [ 'ALA', 'ARG', 'ASH', 'ASN', 'ASP', 'GLH', 'GLN', 'GLU', 'GLY',  'HID', 'HIE', 'HIP',
+                   'ILE', 'LEU', 'LYN', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TYR', 'VAL', 'TRP',]
                    #'CYX' ]
       #resnames = ['HIP', 'HIE', 'HID', 'GLY']
-      resnames = ['ALA', 'GLY', 'PRO', 'CYS']#, 'HIE', 'HID']
+      #resnames = ['ALA', 'GLY', 'PRO', 'CYS']#, 'HIE', 'HID']
     else:
-      #resnames = [ 'ALA', 'ARG', 'ASN', 'ASP', 'GLN', 'GLU', 'GLY', 'HID', 'HIE', 'HIP',
-      #             'ILE', 'LEU', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TYR', 'VAL', 'TRP',
-      #             'CYX' ]
+      resnames = [ 'ALA', 'ARG', 'ASN', 'ASP', 'GLN', 'GLU', 'GLY', 'HID', 'HIE', 'HIP',
+                   'ILE', 'LEU', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TYR', 'VAL', 'TRP',
+                   'CYX' ]
       #resnames = ['HIP', 'HIE', 'HID', 'GLY']
-      resnames = []
+      #resnames = []
     for resa, resb in itertools.permutations(resnames, 2):
         
         resname = f'{resa}_{resb}'
@@ -85,7 +85,11 @@ for folder in ['MainChain', 'CTerminal', 'NTerminal']:#, 'MainChain']:
         #off_top.box_vectors = [[48, 0, 0], [0, 48, 0], [0, 0, 48]] * unit.angstrom
         #print('off_box', off_top.box_vectors)
         #print('amb_box', pmd_struct.box)
-        off_sys = ff.create_openmm_system(mol.to_topology(),)#allow_nonintegral_charges=True)
+        try:
+            off_sys = ff.create_openmm_system(mol.to_topology(),)#allow_nonintegral_charges=True)
+        except Exception as e:
+            print(e)
+            continue
         #nonbonded_force = [force for force in off_sys.getForces() if isinstance(force, openmm.NonbondedForce)][0]
         #nonbonded_force.createExceptionsFromBonds([(bond.atom1.molecule_atom_index,
         #                                            bond.atom2.molecule_atom_index) for bond in mol.bonds],


### PR DESCRIPTION
- [x] Closes #26 

_Controls_ for the different explicit single/double bonding patterns in valid of _HIS resonance forms_ / protomers / charge states (HIP/HID/HIE) by doing a SMARTS search on the pattern `[C:1]1~[C:2]~[N:3]~[C:4]~[N:5]1` (generic form for imidazole) and removing bond orders and formal charges from all matching atoms/bonds. 

**Additional context**

This seems like a perfect opportunity for a pun involving "Hiss Resonance" from the [video game Control (spoilers)](https://control.fandom.com/wiki/The_Hiss) but I'm drawing a total blank. 