### PR TITLE
Capture NTerminal backbone parameters and exclude malformed structures

### DIFF
--- a/ConvertBackboneParameters.py
+++ b/ConvertBackboneParameters.py
@@ -159,6 +159,14 @@ def get_smarts(prefix, atom_idxs):
       atom_indices_of_interest.add(atom_idx)
       for neighbor in oeatom.GetAtoms():
         atom_indices_of_interest.add(neighbor.GetIdx())
+        # Patch to catch N-terminal residue backbone parameters, otherwise
+        # terminal atom backbone torsion gets thrown out since it doesn't
+        # include any atoms in the next residue. 
+        for neighbor2 in neighbor.GetAtoms():
+          if ('NTerminal' in prefix and
+              neighbor2.GetFormalCharge() == 1 and
+              neighbor2.IsNitrogen()):
+            atom_indices_of_interest.add(neighbor2.GetIdx())
 
   # Make a "Subset" molecule, so that we don't get weird charges
   # around where we cleave the residues
@@ -186,10 +194,10 @@ allres = [ 'ALA', 'ARG', 'ASH', 'ASN', 'ASP', 'GLH', 'GLN', 'GLU', 'GLY', 'HID',
            'ILE', 'LEU', 'LYN', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL',
            'CYS']
            #'CYX' ]
-#trmres = [ 'ALA', 'ARG', 'ASN', 'ASP', 'GLN', 'GLU', 'GLY', 'HID', 'HIE', 'HIP', 'ILE', 'LEU',
-#           'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL', 'CYX' ]
+trmres = [ 'ALA', 'ARG', 'ASN', 'ASP', 'GLN', 'GLU', 'GLY', 'HID', 'HIE', 'HIP', 'ILE', 'LEU',
+           'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL'] #, 'CYX' ]
 
-trmres = []
+#trmres = []
 #allres = ['ALA'] #, 'HID', 'HIE']
 #allres = ['HIP', 'HID', 'HIE', 'GLY']
 #trmres = ['HIP', 'HID', 'HIE', 'GLY']

--- a/ConvertBackboneParameters.py
+++ b/ConvertBackboneParameters.py
@@ -159,15 +159,6 @@ def get_smarts(prefix, atom_idxs):
       atom_indices_of_interest.add(atom_idx)
       for neighbor in oeatom.GetAtoms():
         atom_indices_of_interest.add(neighbor.GetIdx())
-        # Patch to catch N-terminal residue backbone parameters, otherwise
-        # terminal atom backbone torsion gets thrown out since it doesn't
-        # include any atoms in the next residue. 
-        for neighbor2 in neighbor.GetAtoms():
-          if ('NTerminal' in prefix and
-              neighbor2.GetFormalCharge() == 1 and
-              neighbor2.IsNitrogen()):
-            atom_indices_of_interest.add(neighbor2.GetIdx())
-
   # Make a "Subset" molecule, so that we don't get weird charges
   # around where we cleave the residues
   subsetmol = OEChem.OEGraphMol()
@@ -190,18 +181,18 @@ def get_smarts(prefix, atom_idxs):
 
 
 # Lists of residues that can occur at various positions on the tripeptide
-allres = [ 'ALA', 'ARG', 'ASH', 'ASN', 'ASP', 'GLH', 'GLN', 'GLU', 'GLY', 'HID', 'HIE', 'HIP',
-           'ILE', 'LEU', 'LYN', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL',
-           'CYS']
+#allres = [ 'ALA', 'ARG', 'ASH', 'ASN', 'ASP', 'GLH', 'GLN', 'GLU', 'GLY', 'HID', 'HIE', 'HIP',
+#           'ILE', 'LEU', 'LYN', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL',
+#           'CYS']
            #'CYX' ]
-trmres = [ 'ALA', 'ARG', 'ASN', 'ASP', 'GLN', 'GLU', 'GLY', 'HID', 'HIE', 'HIP', 'ILE', 'LEU',
-           'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL'] #, 'CYX' ]
+#trmres = [ 'ALA', 'ARG', 'ASN', 'ASP', 'GLN', 'GLU', 'GLY', 'HID', 'HIE', 'HIP', 'ILE', 'LEU',
+#           'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL'] #, 'CYX' ]
 
 #trmres = []
-#allres = ['ALA', 'MET'] #, 'HID', 'HIE']
+allres = ['ALA', 'MET'] #, 'HID', 'HIE']
 #allres = ['HIP', 'HID', 'HIE', 'GLY']
 #trmres = ['HIP', 'HID', 'HIE', 'GLY']
-#trmres = ['ALA', 'MET']
+trmres = ['ALA', 'MET']
 
 # Main chain, N-terminal, and C-terminal residues
 ResClasses = [ 'MainChain', 'NTerminal', 'CTerminal' ]

--- a/ConvertBackboneParameters.py
+++ b/ConvertBackboneParameters.py
@@ -7,7 +7,7 @@ from utils import fix_carboxylate_bond_orders
 import itertools
 
 from amberimpropertorsionhandler import AmberImproperTorsionHandler
-
+from malformed_tripeptides import malformed_tripeptides
 
 def props(cls):
   return [ i for i in cls.__dict__.keys() if i[:1] != '_' ]
@@ -179,6 +179,8 @@ def get_smarts(prefix, atom_idxs):
   return smiles
 
 
+
+
 # Lists of residues that can occur at various positions on the tripeptide
 allres = [ 'ALA', 'ARG', 'ASH', 'ASN', 'ASP', 'GLH', 'GLN', 'GLU', 'GLY', 'HID', 'HIE', 'HIP',
            'ILE', 'LEU', 'LYN', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL',
@@ -242,6 +244,9 @@ for rclass in ResClasses:
   # Loop over all residue combinations
   for resa in arange:
     for resb in arange:
+      if (rclass, (resa, resb)) in malformed_tripeptides:
+        print(f'Skipping {rclass}/{resa}_{resb} because it is known to be mis-formatted')
+        continue
       ppsys = f'{resa}_{resb}'
       topname  = os.path.join(rclass, ppsys, ppsys + '.prmtop')
       mol2name = os.path.join(rclass, ppsys, ppsys + '.mol2')

--- a/ConvertBackboneParameters.py
+++ b/ConvertBackboneParameters.py
@@ -198,10 +198,10 @@ trmres = [ 'ALA', 'ARG', 'ASN', 'ASP', 'GLN', 'GLU', 'GLY', 'HID', 'HIE', 'HIP',
            'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL'] #, 'CYX' ]
 
 #trmres = []
-#allres = ['ALA'] #, 'HID', 'HIE']
+#allres = ['ALA', 'MET'] #, 'HID', 'HIE']
 #allres = ['HIP', 'HID', 'HIE', 'GLY']
 #trmres = ['HIP', 'HID', 'HIE', 'GLY']
-#trmres = ['GLU']
+#trmres = ['ALA', 'MET']
 
 # Main chain, N-terminal, and C-terminal residues
 ResClasses = [ 'MainChain', 'NTerminal', 'CTerminal' ]
@@ -487,8 +487,13 @@ def involves_peptide_bond(prefix, atom_idxs):
   atom_indices_of_interest = set()
   for atom_idx in atom_idxs:
     residues_of_interest.add(pmd_struct.atoms[atom_idx].residue.idx)
-  if len(residues_of_interest & {1,2}) == 2:
-    return True
+  #print(prefix, residues_of_interest)
+  if "NTerminal" in prefix:
+    if len(residues_of_interest & {0,1}) == 2:
+      return True
+  else:
+    if len(residues_of_interest & {1,2}) == 2:
+      return True
   return False
 
   

--- a/malformed_tripeptides.py
+++ b/malformed_tripeptides.py
@@ -1,0 +1,6 @@
+malformed_tripeptides = {('NTerminal', ('THR', 'GLU')),
+                        ('NTerminal', ('MET', 'TYR')),
+                        ('NTerminal', ('LEU', 'MET')),
+                        ('NTerminal', ('HIE', 'LYS')),
+                        ('NTerminal', ('HID', 'MET')),
+                        ('CTerminal', ('PRO', 'THR'))}

--- a/test_parameterize_tripeptides.py
+++ b/test_parameterize_tripeptides.py
@@ -52,6 +52,9 @@ for folder in ['MainChain', 'CTerminal', 'NTerminal']:#, 'MainChain']:
       #resnames = ['HIP', 'HIE', 'HID', 'GLY']
       resnames = []
     for resa, resb in itertools.permutations(resnames, 2):
+      if (folder, (resa, resb)) in malformed_tripeptides:
+        print(f'Skipping {folder}/{resa}_{resb} because it is known to be mis-formatted')
+        continue
         
         resname = f'{resa}_{resb}'
         prefix = os.path.join(folder, resname, resname)

--- a/test_parameterize_tripeptides.py
+++ b/test_parameterize_tripeptides.py
@@ -9,6 +9,7 @@ import os
 import itertools
 
 from amberimpropertorsionhandler import AmberImproperTorsionHandler
+from malformed_tripeptides import malformed_tripeptides
 
 def calc_energy(omm_sys, omm_top, coords):
     omm_idx_to_force = {}
@@ -44,17 +45,18 @@ for folder in ['MainChain', 'CTerminal', 'NTerminal']:#, 'MainChain']:
       #             'ILE', 'LEU', 'LYN', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TYR', 'VAL', 'TRP',]
                    #'CYX' ]
       #resnames = ['HIP', 'HIE', 'HID', 'GLY']
-      resnames = ['ALA', 'GLY', 'PRO', 'CYS']#, 'HIE', 'HID']
+      #resnames = ['ALA', 'GLY', 'PRO', 'CYS']#, 'HIE', 'HID']
+        resnames = []
     else:
       #resnames = [ 'ALA', 'ARG', 'ASN', 'ASP', 'GLN', 'GLU', 'GLY', 'HID', 'HIE', 'HIP',
       #             'ILE', 'LEU', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TYR', 'VAL', 'TRP',
       #             'CYX' ]
-      #resnames = ['HIP', 'HIE', 'HID', 'GLY']
-      resnames = []
+      resnames = ['MET', 'ALA'] #, 'HID', 'GLY']
+      #resnames = []
     for resa, resb in itertools.permutations(resnames, 2):
-      if (folder, (resa, resb)) in malformed_tripeptides:
-        print(f'Skipping {folder}/{resa}_{resb} because it is known to be mis-formatted')
-        continue
+        if (folder, (resa, resb)) in malformed_tripeptides:
+            print(f'Skipping {folder}/{resa}_{resb} because it is known to be mis-formatted')
+            continue
         
         resname = f'{resa}_{resb}'
         prefix = os.path.join(folder, resname, resname)


### PR DESCRIPTION
- [x] Changes the logic for taking backbone parameters to include collection of NTerminal inter-residue backbone params
- [x] Rename `ConvertTripeptideParameters.py` to `ConvertBackboneParameters.py`
- [x] Explicitly exclude malformed mol2 files (#28)