### PR TITLE
Update for OpenFF Toolkit namespace migration

### DIFF
--- a/CombineOffxmls.py
+++ b/CombineOffxmls.py
@@ -1,4 +1,8 @@
-from openforcefield.typing.engines.smirnoff import ForceField
+try:
+    from openff.toolkit.typing.engines.smirnoff import ForceField
+except ImportError:
+    from openforcefield.typing.engines.smirnoff import ForceField
+
 from amberimpropertorsionhandler import AmberImproperTorsionHandler
 
 ff = ForceField('result_residues.offxml', 'result_backbone.offxml')

--- a/CombineOffxmls.py
+++ b/CombineOffxmls.py
@@ -1,7 +1,4 @@
-try:
-    from openff.toolkit.typing.engines.smirnoff import ForceField
-except ImportError:
-    from openforcefield.typing.engines.smirnoff import ForceField
+from openff.toolkit.typing.engines.smirnoff import ForceField
 
 from amberimpropertorsionhandler import AmberImproperTorsionHandler
 

--- a/ConvertBackboneParameters.py
+++ b/ConvertBackboneParameters.py
@@ -1,10 +1,14 @@
 import sys, os, copy
 import openeye.oechem as OEChem
 import parmed as ParmEd
-from openforcefield.topology import Molecule
 from simtk import unit
 from utils import fix_carboxylate_bond_orders
 import itertools
+
+try:
+    from openff.toolkit.topology import Molecule
+except ImportError:
+    from openforcefield.topology import Molecule
 
 from amberimpropertorsionhandler import AmberImproperTorsionHandler
 from malformed_tripeptides import malformed_tripeptides

--- a/ConvertBackboneParameters.py
+++ b/ConvertBackboneParameters.py
@@ -5,10 +5,7 @@ from simtk import unit
 from utils import fix_carboxylate_bond_orders
 import itertools
 
-try:
-    from openff.toolkit.topology import Molecule
-except ImportError:
-    from openforcefield.topology import Molecule
+from openff.toolkit.topology import Molecule
 
 from amberimpropertorsionhandler import AmberImproperTorsionHandler
 from malformed_tripeptides import malformed_tripeptides
@@ -731,9 +728,9 @@ improper_dicts.sort(key=sort_method)
 
 
 # Initialize an empty force field
-from openforcefield.typing.engines.smirnoff import ForceField
+from openff.toolkit.typing.engines.smirnoff import ForceField
 ff = ForceField()
-ff._set_aromaticity_model('OEAroModel_MDL')
+ff.aromaticity_model = 'OEAroModel_MDL'
 
 # Loop over the parameters to convert and their corresponding SMIRNOFF header tags 
 for smirnoff_tag, param_dicts in { "Bonds": bond_dicts, "Angles": angle_dicts,
@@ -750,7 +747,7 @@ for smirnoff_tag, param_dicts in { "Bonds": bond_dicts, "Angles": angle_dicts,
   # Loop over the list of parameter dictionaries, using each one as an input to
   # handler.add_parameter.  This mimics deserializing an OFFXML into a ForceField
   # object, and will do any sanitization that we might otherwise miss
-  from openforcefield.typing.engines.smirnoff.parameters import DuplicateParameterError
+  from openff.toolkit.typing.engines.smirnoff.parameters import DuplicateParameterError
   for param_dict in param_dicts:
     try:
       handler.add_parameter(param_dict)

--- a/ConvertResidueParameters.py
+++ b/ConvertResidueParameters.py
@@ -4,10 +4,7 @@ import parmed as ParmEd
 from simtk import unit
 from utils import fix_carboxylate_bond_orders
 
-try:
-    from openff.toolkit.topology import Molecule
-except ImportError:
-    from openforcefield.topology import Molecule
+from openff.toolkit.topology import Molecule
 
 from amberimpropertorsionhandler import AmberImproperTorsionHandler
 
@@ -729,9 +726,9 @@ nonbond_dicts.sort(key=sort_method)
 
 
 # Initialize an empty force field
-from openforcefield.typing.engines.smirnoff import ForceField
+from openff.toolkit.typing.engines.smirnoff import ForceField
 ff = ForceField()
-ff._set_aromaticity_model('OEAroModel_MDL')
+ff.aromaticity_model = 'OEAroModel_MDL'
 
 # Loop over the parameters to convert and their corresponding SMIRNOFF header tags 
 for smirnoff_tag, param_dicts in { "Bonds": bond_dicts, "Angles": angle_dicts,
@@ -747,7 +744,7 @@ for smirnoff_tag, param_dicts in { "Bonds": bond_dicts, "Angles": angle_dicts,
   # Loop over the list of parameter dictionaries, using each one as an input to
   # handler.add_parameter.  This mimics deserializing an OFFXML into a ForceField
   # object, and will do any sanitization that we might otherwise miss
-  from openforcefield.typing.engines.smirnoff.parameters import DuplicateParameterError
+  from openff.toolkit.typing.engines.smirnoff.parameters import DuplicateParameterError
   for param_dict in param_dicts:
     try:
       handler.add_parameter(param_dict)

--- a/ConvertResidueParameters.py
+++ b/ConvertResidueParameters.py
@@ -1,9 +1,13 @@
 import sys, os, copy
 import openeye.oechem as OEChem
 import parmed as ParmEd
-from openforcefield.topology import Molecule
 from simtk import unit
 from utils import fix_carboxylate_bond_orders
+
+try:
+    from openff.toolkit.topology import Molecule
+except ImportError:
+    from openforcefield.topology import Molecule
 
 from amberimpropertorsionhandler import AmberImproperTorsionHandler
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a work in progress. Changes should be committed to `master` at this poin
 
 Requires an OE license.
 
-`conda install -c conda-forge -c omnia -c openeye ambertools openforcefield openeye-toolkits`
+`conda install -c conda-forge -c openeye ambertools openff-toolkit openeye-toolkits`
 
 * `GenerateSystems.sh` will use AMBERTools to generate various dipepetides
 * `ConvertParameters.py` will attempt to convert prmtops to OFFXML

--- a/amberimpropertorsionhandler.py
+++ b/amberimpropertorsionhandler.py
@@ -1,11 +1,6 @@
-try:
-    from openff.toolkit.typing.engines.smirnoff import ImproperTorsionHandler, ParameterAttribute, IndexedParameterAttribute
-    from openff.toolkit.typing.engines.smirnoff.parameters import _allow_only
-    from openff.toolkit.topology.topology import _TransformedDict
-except ImportError:
-    from openforcefield.topology.topology import _TransformedDict
-    from openforcefield.typing.engines.smirnoff import ImproperTorsionHandler, ParameterAttribute, IndexedParameterAttribute
-    from openforcefield.typing.engines.smirnoff.parameters import _allow_only
+from openff.toolkit.typing.engines.smirnoff import ImproperTorsionHandler, ParameterAttribute, IndexedParameterAttribute
+from openff.toolkit.typing.engines.smirnoff.parameters import _allow_only
+from openff.toolkit.topology.topology import _TransformedDict
 
 try:
     import openmm
@@ -64,7 +59,7 @@ class AmberImproperTorsionHandler(ImproperTorsionHandler):
 
         Parameters
         ----------
-        entity : openforcefield.topology.Topology
+        entity : openff.toolkit.topology.Topology
             Topology to search.
 
         Returns

--- a/amberimpropertorsionhandler.py
+++ b/amberimpropertorsionhandler.py
@@ -1,6 +1,16 @@
-from openforcefield.typing.engines.smirnoff import ImproperTorsionHandler, ParameterAttribute, IndexedParameterAttribute
-from openforcefield.typing.engines.smirnoff.parameters import _allow_only
-from simtk import openmm
+try:
+    from openff.toolkit.typing.engines.smirnoff import ImproperTorsionHandler, ParameterAttribute, IndexedParameterAttribute
+    from openff.toolkit.typing.engines.smirnoff.parameters import _allow_only
+    from openff.toolkit.topology.topology import _TransformedDict
+except ImportError:
+    from openforcefield.topology.topology import _TransformedDict
+    from openforcefield.typing.engines.smirnoff import ImproperTorsionHandler, ParameterAttribute, IndexedParameterAttribute
+    from openforcefield.typing.engines.smirnoff.parameters import _allow_only
+
+try:
+    import openmm
+except ImportError:
+    from simtk import openmm
 
 # TODO: There's a lot of duplicated code in ProperTorsionHandler and ImproperTorsionHandler
 class AmberImproperTorsionHandler(ImproperTorsionHandler):
@@ -33,7 +43,6 @@ class AmberImproperTorsionHandler(ImproperTorsionHandler):
     )
     default_idivf = ParameterAttribute(default='auto')
 
-    from openforcefield.topology.topology import _TransformedDict
     class AmberImproperDict(_TransformedDict):
         """Symmetrize improper torsions."""
         

--- a/fix_carboxylate_cli.py
+++ b/fix_carboxylate_cli.py
@@ -1,9 +1,6 @@
 from utils import fix_carboxylate_bond_orders
 import sys
-try:
-    from openff.toolkit.topology import Molecule
-except ImportError:
-    from openforcefield.topology import Molecule
+from openff.toolkit.topology import Molecule
 
 if len(sys.argv) != 2:
     print("python fix_carboxylate_cli.py file.mol2")

--- a/fix_carboxylate_cli.py
+++ b/fix_carboxylate_cli.py
@@ -1,6 +1,9 @@
 from utils import fix_carboxylate_bond_orders
 import sys
-from openforcefield.topology import Molecule
+try:
+    from openff.toolkit.topology import Molecule
+except ImportError:
+    from openforcefield.topology import Molecule
 
 if len(sys.argv) != 2:
     print("python fix_carboxylate_cli.py file.mol2")

--- a/test_parameterize_dipeptides.py
+++ b/test_parameterize_dipeptides.py
@@ -1,5 +1,5 @@
-from openforcefield.topology import Molecule
-from openforcefield.typing.engines.smirnoff import ForceField
+from openff.toolkit.topology import Molecule
+from openff.toolkit.typing.engines.smirnoff import ForceField
 import parmed as ParmEd
 from simtk import openmm
 from simtk.openmm import app, unit, XmlSerializer, LangevinIntegrator

--- a/test_parameterize_tripeptides.py
+++ b/test_parameterize_tripeptides.py
@@ -1,5 +1,4 @@
 from openforcefield.topology import Molecule
-from openforcefield.typing.engines.smirnoff import ForceField
 import parmed as ParmEd
 from simtk import openmm
 from simtk.openmm import app, unit, XmlSerializer, LangevinIntegrator
@@ -7,6 +6,13 @@ from simtk.openmm.app import NoCutoff, HBonds
 from utils import fix_carboxylate_bond_orders
 import os
 import itertools
+
+try:
+    from openff.toolkit.typing.engines.smirnoff import ForceField
+    from openff.toolkit.topology import Molecule
+except ImportError:
+    from openforcefield.topology import Molecule
+    from openforcefield.typing.engines.smirnoff import ForceField
 
 from amberimpropertorsionhandler import AmberImproperTorsionHandler
 from malformed_tripeptides import malformed_tripeptides

--- a/test_parameterize_tripeptides.py
+++ b/test_parameterize_tripeptides.py
@@ -1,4 +1,3 @@
-from openforcefield.topology import Molecule
 import parmed as ParmEd
 from simtk import openmm
 from simtk.openmm import app, unit, XmlSerializer, LangevinIntegrator
@@ -7,12 +6,8 @@ from utils import fix_carboxylate_bond_orders
 import os
 import itertools
 
-try:
-    from openff.toolkit.typing.engines.smirnoff import ForceField
-    from openff.toolkit.topology import Molecule
-except ImportError:
-    from openforcefield.topology import Molecule
-    from openforcefield.typing.engines.smirnoff import ForceField
+from openff.toolkit.typing.engines.smirnoff import ForceField
+from openff.toolkit.topology import Molecule
 
 from amberimpropertorsionhandler import AmberImproperTorsionHandler
 from malformed_tripeptides import malformed_tripeptides


### PR DESCRIPTION
I needed to update `amberimpropertorsionhandler.py` to import the parameter handler. I also mindlessly updated the other Python files. It might be better to vendor than upstream this, I'm not sure.